### PR TITLE
Feat add cli

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,10 @@
             "files": [
                 "*.ts",
                 "*.tsx"
-            ]
+            ],
+          "rules": {
+            "@typescript-eslint/no-extraneous-class": "off"
+          }
         }
     ],
     "parserOptions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -872,6 +872,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "commander": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@angular-devkit/schematics-cli": "^14.1.3",
     "@nestjs/schematics": "^8.0.11",
     "@schematics/angular": "^14.1.2",
+    "commander": "^9.4.0",
     "schematics-utilities": "^2.0.3"
   },
   "devDependencies": {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import {Command} from 'commander';
+import {version} from '../../package.json';
+import {NewCommand} from './commands/new.command';
+
+const init = () => {
+	const program = new Command('cuckoo');
+
+	program
+		.version(
+			version,
+			'-v, --version',
+			'output the current version',
+		)
+		.helpOption('-h, --help', 'output usage information')
+		.showHelpAfterError()
+		.usage('<command> [options]')
+
+		.command('new <name>')
+		.alias('n')
+		.description('generate a new NestJS project scaffolding')
+		.action(async (name: string, _options: any) => {
+			await NewCommand.execute(name);
+		});
+
+	program.parse(process.argv);
+};
+
+init();

--- a/src/cli/commands/new.command.ts
+++ b/src/cli/commands/new.command.ts
@@ -1,0 +1,16 @@
+import {SchematicRunner} from '../lib/runners/schematic.runner';
+
+export class NewCommand {
+	public static async execute(name: string, _path?: string) {
+		try {
+			await this.generateNestApplication(name);
+		} catch (error: unknown) {
+			process.exit(1);
+		}
+	}
+
+	private static async generateNestApplication(name: string) {
+		const runner = new SchematicRunner(['@nestjs/schematics:application', `--name ${name}`]);
+		await runner.run();
+	}
+}

--- a/src/cli/lib/runners/generic.runner.ts
+++ b/src/cli/lib/runners/generic.runner.ts
@@ -1,0 +1,39 @@
+import type {SpawnOptions} from 'child_process';
+import {spawn} from 'child_process';
+
+export class GenericRunner {
+	constructor(protected binary: string) {}
+
+	protected async run(
+		command: string,
+		args: string [] = [],
+		cwd: string = process.cwd(),
+	): Promise<string | void> {
+		const options: SpawnOptions = {
+			cwd,
+			stdio: 'pipe',
+			shell: true,
+		};
+
+		return new Promise((resolve, reject) => {
+			const child = spawn(
+				this.binary,
+				args = [command, ...args],
+				options,
+			);
+
+			child.on('error', error => {
+				reject(new Error(`Child process filed with error: ${error.message}`));
+			});
+
+			child.on('close', code => {
+				if (code === 0) {
+					resolve();
+					return;
+				}
+
+				reject(new Error(`Failed to execute command: ${this.binary} ${args.join(' ')}`));
+			});
+		});
+	}
+}

--- a/src/cli/lib/runners/schematic.runner.ts
+++ b/src/cli/lib/runners/schematic.runner.ts
@@ -1,0 +1,18 @@
+import {GenericRunner} from './generic.runner';
+
+export class SchematicRunner extends GenericRunner {
+	private static getSchematicPath(): string {
+		return require.resolve(
+			'@angular-devkit/schematics-cli/bin/schematics.js',
+			{paths: module.paths},
+		);
+	}
+
+	constructor(private readonly args: string[] = []) {
+		super('node');
+	}
+
+	public async run() {
+		await super.run(SchematicRunner.getSchematicPath(), this.args);
+	}
+}


### PR DESCRIPTION
### Main changes

- :new: (feat)
- :wrench: (chore)

On this PR I've added a basic CLI with the `new <name>` command that generates a NestJS application. It uses the `schematics-cli` executable to run the `@nestjs/schematics:application`. I think we don't need to run our own schematics yet. In the future, if we do need to, I'd recommend generating individual packages and publishing them to npm so we can call them easily with schematics CLI.

In the next PR, I'll remove our schematics since we don't really need them. The `application` schematic generates a NestJS application that we can do directly with the code in this PR. And the additional task to run `git init` and `npm i` schematics can be replaced by spawning a child process (which is what these schematics do anyway).
